### PR TITLE
Fix #3, prevent runnable jar issues.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-  compile("org.springframework.boot:spring-boot-starter-web")
+  compile("org.springframework.boot:spring-boot-starter")
   compile("org.grails:gorm-hibernate4-spring-boot:1.1.0.RELEASE")
   runtime("com.h2database:h2")
 

--- a/src/test/groovy/com/rimerosolutions/gorm/IntegrationDomainSpec.groovy
+++ b/src/test/groovy/com/rimerosolutions/gorm/IntegrationDomainSpec.groovy
@@ -73,14 +73,15 @@ class IntegrationDomainSpec extends Specification {
     PersonService personService = context.getBean(PersonService)
 
     // Dummy user objects to persist
+    given:
     def persons = [
       new Person("firstName":"Franscisco", "lastName":"DelaNoche"),
       new Person("firstName":"Emmanuel", "lastName":"Dupuit")
     ]
 
     when: 'When the person information is correct'
-    persons.each { Person person ->
-      personService.validate(person)
+    persons.each { Person person -> 
+      assert personService.validate(person)
     }
 
     then: 'We save the list of valid persons'


### PR DESCRIPTION
The changes take care of runnable jar via `java -jar`.

`gradle bootRun` still works.
